### PR TITLE
increase data read/write buffer

### DIFF
--- a/io.c
+++ b/io.c
@@ -16,6 +16,7 @@ along with this program; see the file COPYING. If not, see
 
 #include <errno.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <sys/errno.h>
 
@@ -59,25 +60,29 @@ io_nwrite(int fd, const void* buf, size_t n) {
 int
 io_ncopy(int fd_in, int fd_out, size_t size) {
   size_t copied = 0;
-  char buf[0x4000];
+  size_t buf_size = size > DATA_BUFFER_SIZE ? DATA_BUFFER_SIZE : size;
+  char* buf = malloc(buf_size);
   ssize_t n;
 
   while(copied < size) {
     n = size - copied;
-    if(n > sizeof(buf)) {
-      n = sizeof(buf);
+    if(n > buf_size) {
+      n = buf_size;
     }
 
     if(io_nread(fd_in, buf, n)) {
+      free(buf);
       return -1;
     }
     if(io_nwrite(fd_out, buf, n)) {
+      free(buf);
       return -1;
     }
 
     copied += n;
   }
 
+  free(buf);
   return 0;
 }
 

--- a/io.h
+++ b/io.h
@@ -18,6 +18,10 @@ along with this program; see the file COPYING. If not, see
 
 #include <stddef.h>
 
+/**
+ * data buffer size 1MB
+ */
+#define DATA_BUFFER_SIZE 0x100000
 
 /**
  * Read exactly N bytes from the given file descriptor.


### PR DESCRIPTION
change the file read/write buffer size to 1MB,
before it's a fixed size of 16KB

It avoid read/write small data trunk from disk,
and will improve the speed for download and upload.
upload testing shows it could double the transfer speed.