### PR TITLE
Makefile.ps5: Add missing assets to list.

### DIFF
--- a/Makefile.ps5
+++ b/Makefile.ps5
@@ -26,6 +26,7 @@ endif
 VERSION_TAG := $(shell git describe --abbrev=6 --dirty --always --tags)
 TITLE_ID    := BREW10001
 ASSETS      := assets/param.json assets/icon0.png assets/websrv.html
+ASSETS      += assets/xterm.min.js assets/xterm.min.css ftpsrv-ps5.elf
 
 CFLAGS := -Wall -Werror -DVERSION_TAG=\"$(VERSION_TAG)\" -I.
 CFLAGS += -DTITLE_ID=\"$(TITLE_ID)\"


### PR DESCRIPTION
[`install-ps5.c`](https://github.com/ps5-payload-dev/ftpsrv/blob/f8833f4c381824eeceb811fb9045440e125319cd/install-ps5.c#L47) includes 6 assets, but only 3 are listed in the Makefile. Missing `ftpsrv-ps5.elf` from the list allows `make` to try building `ftpsrv-ps5-install.elf` before `ftpsrv-ps5.elf` is available.

That can happen, for example, when a build script automatically sets the environment variable `MAKEFLAGS="-j2"`, resulting in:
```
/opt/ps5-payload-sdk/bin/prospero-clang -Wall -Werror -DVERSION_TAG=\"d5cf56-dirty\" -I. -DTITLE_ID=\"BREW10001\" -o ftpsrv-ps5.elf srv.c cmd.c notify.c io.c self.c sha256.c main-prospero.c cmd-prospero.c self-prospero.c io-freebsd.c
/opt/ps5-payload-sdk/bin/prospero-clang -Wall -Werror -DVERSION_TAG=\"d5cf56-dirty\" -I. -DTITLE_ID=\"BREW10001\" -o ftpsrv-ps5-install.elf install-ps5.c -lSceIpmi -lSceAppInstUtil
<inline asm>:7:9: error: Could not find incbin file 'ftpsrv-ps5.elf'
    7 | .incbin "ftpsrv-ps5.elf"
      |         ^
1 error generated.
make: *** [Makefile:43: ftpsrv-ps5-install.elf] Error 1
make: *** Waiting for unfinished jobs....
```

This PR fixes the build failure bug and includes the other 2 missing assets for completeness.